### PR TITLE
Add optional @tailwindcss/oxide-linux-x64-gnu dependency to ensure Tailwind native binding is installed

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,9 @@
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
         "typescript": "^5"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1318,7 +1321,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,5 +22,8 @@
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "optionalDependencies": {
+    "@tailwindcss/oxide-linux-x64-gnu": "4.2.2"
   }
 }


### PR DESCRIPTION
### Motivation
- Builds were failing with a missing native binding error for `@tailwindcss/oxide-linux-x64-gnu` due to npm optional dependency resolution, which prevented `@tailwindcss/oxide` from loading during Next.js/Tailwind usage.
- An explicit top-level optional dependency ensures the Linux x64 native binding is present in environments that require it.

### Description
- Added `@tailwindcss/oxide-linux-x64-gnu@4.2.2` to `optionalDependencies` in `frontend/package.json`.
- Updated `frontend/package-lock.json` root metadata to include the same optional dependency so lockfile and package manifest are consistent.

### Testing
- Ran `cd frontend && npm install`, which completed successfully.
- Ran `cd frontend && npm run build`, which removed the Tailwind native binding error and allowed compilation to proceed, but the build ultimately failed later due to an existing TypeScript error (`app/private/page.tsx is not a module`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25125ec488332a68fad5cbfceed76)