### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/enforce-prod-test.yml
+++ b/.github/workflows/enforce-prod-test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-source-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/RGSS-CS/williams-rgss-website-dev-frontend/security/code-scanning/1](https://github.com/RGSS-CS/williams-rgss-website-dev-frontend/security/code-scanning/1)

To fix this, add an explicit `permissions` block in `.github/workflows/enforce-prod-test.yml` so the workflow does not inherit potentially broad defaults.

Best fix (without changing behavior): define minimal permissions at the workflow root so it applies to all jobs in this file. For this workflow, `contents: read` is sufficient and aligns with least privilege for a PR branch-check job.

Change region:
- File: `.github/workflows/enforce-prod-test.yml`
- Insert `permissions:` block after the `on:` trigger section and before `jobs:`.

No imports, methods, or dependencies are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
