### PR TITLE
Enforce strict networking naming

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -21,3 +21,5 @@ networks:
   internetwork:
     external: true
     name: internetwork
+    driver: bridge
+    

--- a/compose.yml
+++ b/compose.yml
@@ -20,3 +20,4 @@ services:
 networks:
   internetwork:
     external: true
+    name: internetwork


### PR DESCRIPTION
Fix #107 by enforcing strict docker network naming to prevent frontend-backend containers network mismatch