### PR TITLE
Build frontend Docker image for AMD64 and ARM64

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -51,6 +51,10 @@ jobs:
             type=raw,value=latest,enable=true
             type=sha,prefix=sha-,format=short
 
+      # QEMU lets the amd64 GitHub-hosted runner build ARM64 layers.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -69,6 +73,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./frontend
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- enable QEMU emulation on the GitHub-hosted AMD64 runner
- publish the frontend image for both `linux/amd64` and `linux/arm64`
- preserve the existing `latest` and SHA-based GHCR tags as multi-platform manifests

## Verification

- reviewed the workflow after the update
- confirmed the `node:20-alpine`-based Dockerfile supports both target architectures
- the existing Docker test workflow will run on this pull request