### PR TITLE
Fix frontend clean Docker dependency install

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "next": "^16.2.12",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "sharp": "^0.35.3"
+        "sharp": "0.35.3"
       },
       "devDependencies": {
         "@types/node": "^20.19.41",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "next": "^16.2.12",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "sharp": "^0.35.3"
+    "sharp": "0.35.3"
   },
   "devDependencies": {
     "@types/node": "^20.19.41",


### PR DESCRIPTION
## Summary

- pin the direct `sharp` dependency to the existing locked version `0.35.3`
- synchronize the root dependency requirement in `package-lock.json`
- restore clean `npm ci` installs for both AMD64 and ARM64 Docker builds

## Cause

The multi-architecture publish exposed a pre-existing lock consistency problem. `package.json` allowed npm to resolve `sharp 0.35.4`, while the lockfile contained `sharp 0.35.3` and its matching `@img/sharp-*` packages. The cached AMD64 dependency layer hid the issue; the uncached ARM64 layer failed validation.

The GitHub Actions Node 20 and `punycode` messages in the log are deprecation warnings and are not the build failure.